### PR TITLE
Centralize URLs into config

### DIFF
--- a/LegalDesktop/Services/ApiService.cs
+++ b/LegalDesktop/Services/ApiService.cs
@@ -3,6 +3,7 @@ using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
 using System.Windows;
+using LegalDesktop.Services;
 
 namespace LegalDesktop.Services
 {
@@ -28,8 +29,7 @@ namespace LegalDesktop.Services
 
             try
             {
-                //  var response = await _httpClient.PostAsync("https://localhost:7067/api/Users/login", content);
-                var response = await _httpClient.PostAsync("https://cncivil04.pjn.gov.ar/legaltrack/api/Users/login", content);
+                var response = await _httpClient.PostAsync(AppConfig.LoginEndpoint, content);
 
                 if (response.IsSuccessStatusCode)
                 {

--- a/LegalDesktop/Services/AppConfig.cs
+++ b/LegalDesktop/Services/AppConfig.cs
@@ -1,0 +1,11 @@
+namespace LegalDesktop.Services
+{
+    public static class AppConfig
+    {
+        public static string BaseApiUrl { get; set; } = "https://cncivil04.pjn.gov.ar/legaltrack/";
+        public static string LoginEndpoint => $"{BaseApiUrl}api/Users/login";
+        public static string DocumentationUrl { get; set; } = "https://ruta-a-la-documentacion";
+        public static string SigPolicyUri { get; set; } = "http://pki.jgm.gov.ar/cps/cps.pdf";
+        public static string Pkcs11LibraryPath { get; set; } = @"C:\\Windows\\SysWOW64\\aetpkss1.dll";
+    }
+}

--- a/LegalDesktop/Services/StarSignTokenService.cs
+++ b/LegalDesktop/Services/StarSignTokenService.cs
@@ -15,7 +15,6 @@ namespace LegalDesktop.Services
 {
     public class StarSignTokenService : IDisposable
     {
-        public const string Pkcs11LibraryPath = @"C:\Windows\SysWOW64\aetpkss1.dll";
         private readonly Pkcs11InteropFactories _factories = new Pkcs11InteropFactories();
         private IPkcs11Library _pkcs11Library;
         private ISlot _slot;
@@ -23,12 +22,12 @@ namespace LegalDesktop.Services
 
         public bool Initialize()
         {
-            if (!File.Exists(Pkcs11LibraryPath))
+            if (!File.Exists(AppConfig.Pkcs11LibraryPath))
                 throw new FileNotFoundException("DLL de StarSign no encontrada.");
 
             _pkcs11Library = _factories.Pkcs11LibraryFactory.LoadPkcs11Library(
                 _factories,
-                Pkcs11LibraryPath,
+                AppConfig.Pkcs11LibraryPath,
                 AppType.SingleThreaded
             );
 
@@ -119,7 +118,7 @@ namespace LegalDesktop.Services
                 var sigPolicy = new PdfDictionary();
                 sigPolicy.Put(new PdfName("SigPolicyId"), new PdfString("2.16.32.1.1.3")); // OID
                 sigPolicy.Put(new PdfName("SigPolicyDescription"), new PdfString("Política de Firma Digital Argentina"));
-                sigPolicy.Put(new PdfName("SigPolicyUri"), new PdfString("http://pki.jgm.gov.ar/cps/cps.pdf"));
+                sigPolicy.Put(new PdfName("SigPolicyUri"), new PdfString(AppConfig.SigPolicyUri));
 
                 signatureDic.Put(PdfName.FILTER, PdfName.ADOBE_PPKLITE);
                 signatureDic.Put(PdfName.SUBFILTER, PdfName.ADBE_PKCS7_DETACHED);

--- a/LegalDesktop/Services/TokenDetectorService.cs
+++ b/LegalDesktop/Services/TokenDetectorService.cs
@@ -53,13 +53,13 @@ internal class TokenDetectorService
         try
         {
             // Implementación específica para detectar StarSign
-            if (!File.Exists(StarSignTokenService.Pkcs11LibraryPath))
+            if (!File.Exists(AppConfig.Pkcs11LibraryPath))
                 return false;
 
             var factories = new Pkcs11InteropFactories();
             using (var pkcs11Library = factories.Pkcs11LibraryFactory.LoadPkcs11Library(
                 factories,
-                StarSignTokenService.Pkcs11LibraryPath,
+                AppConfig.Pkcs11LibraryPath,
                 AppType.SingleThreaded))
             {
                 var slots = pkcs11Library.GetSlotList(SlotsType.WithTokenPresent);

--- a/LegalDesktop/ViewModels/MainViewModel.cs
+++ b/LegalDesktop/ViewModels/MainViewModel.cs
@@ -8,6 +8,7 @@ using System.Net.Http;
 using System.Windows;
 using System.Windows.Input;
 using System.Windows.Threading;
+using LegalDesktop.Services;
 using System.Xml.Linq;
 using LegalDesktop.Models;
 using LegalDesktop.Models.Dtos;
@@ -41,8 +42,7 @@ public class MainViewModel : INotifyPropertyChanged
 );
     private readonly string _signedPdfsFolder = Path.Combine(
         Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "LegalDesktop", "SignedPdfs");
-     private readonly string url = "https://cncivil04.pjn.gov.ar/legaltrack/";
-    // private readonly string url = "https://localhost:7067/";
+    private readonly string url = AppConfig.BaseApiUrl;
 
     public ObservableCollection<PdfModel> PdfFiles { get; set; }
     private FileSystemWatcher _watcher; // Observador de cambios en la carpeta

--- a/LegalDesktop/Views/InfoWindow.xaml.cs
+++ b/LegalDesktop/Views/InfoWindow.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using System.Diagnostics;
 using System.Windows;
 using System.Windows.Navigation;
+using LegalDesktop.Services;
 
 namespace LegalDesktop.Views
 {
@@ -17,8 +18,7 @@ namespace LegalDesktop.Views
         }
         private void DocumentationButton_Click(object sender, RoutedEventArgs e)
         {
-            string url = "https://ruta-a-la-documentacion"; // Reemplazalo por tu URL real o path local
-            Process.Start(new ProcessStartInfo(url) { UseShellExecute = true });
+            Process.Start(new ProcessStartInfo(AppConfig.DocumentationUrl) { UseShellExecute = true });
         }
         private void Close_Click(object sender, RoutedEventArgs e)
         {


### PR DESCRIPTION
## Summary
- centralize API URLs and documentation link in a new `AppConfig` class
- use `AppConfig` constants in `ApiService`, `MainViewModel`, and `InfoWindow`
- also use `AppConfig` paths for PKCS#11 library and signature policy
- update token detector to use new config

